### PR TITLE
Fixes security hole

### DIFF
--- a/UI/Web/firstrun.aspx.cs
+++ b/UI/Web/firstrun.aspx.cs
@@ -11,6 +11,14 @@ public partial class firstrun : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
+        //don't let them create a user if a user already exists
+        OSAEObjectCollection objects = new OSAEObjectCollection();
+        objects = OSAEObjectManager.GetObjectsByType("PERSON");
+
+        if (objects.Count > 0)
+        {
+            Response.Redirect("~/Default.aspx");
+        }
     }
     protected void createUserLinkButton_Click(object sender, EventArgs e)
     {


### PR DESCRIPTION
The firstrun.aspx page would always allow you to create a new user with
access.  This fix will only allow users to be created when no user
exists.
